### PR TITLE
fix(docs): use uvx for MCP server startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,10 @@ Add the following configuration to your relative mcp config list
 
 ```json
 {
-  "mcpServers": 
-    ...
-    {
+  "mcpServers": {
     "swanlab-mcp": {
-      "command": "uv",
-      "args": ["run", "swanlab_mcp", "--transport", "stdio"],
+      "command": "uvx",
+      "args": ["--from", "swanlab-mcp", "swanlab_mcp", "--transport", "stdio"],
       "env": {
         "SWANLAB_API_KEY": "your_api_key_here"
       }
@@ -51,7 +49,7 @@ Add the following configuration to your relative mcp config list
 For `Claude Code` Users, you can config like this:
 
 ```bash
-claude mcp add --env SWANLAB_API_KEY=<your_api_key> -- swanlab_mcp uv run swanlab_mcp --transport stdio
+claude mcp add --env SWANLAB_API_KEY=<your_api_key> -- swanlab-mcp uvx --from swanlab-mcp swanlab_mcp --transport stdio
 ```
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

The current README instructs users to start the MCP server with `uv run swanlab_mcp`, which requires cloning the repository and running from a local project context. Since `swanlab-mcp` is already published on PyPI, the recommended approach for end users is to use `uvx`, which runs the tool in an isolated environment without needing the source code.

Additionally, because the executable name (`swanlab_mcp`, with underscore) differs from the package name (`swanlab-mcp`, with hyphen), `uvx swanlab-mcp` alone does not work — `uvx` will look for an executable matching the package name and fail:

```
The executable `swanlab-mcp` was not found.
An executable named `swanlab-mcp` is not provided by package `swanlab-mcp`.
The following executables are provided by `swanlab-mcp`:
- swanlab_mcp
```

The correct invocation requires the `--from` flag:

```bash
uvx --from swanlab-mcp swanlab_mcp --transport stdio
```

## Changes

- **JSON config**: Changed `"command": "uv"` with `"args": ["run", ...]` to `"command": "uvx"` with `"args": ["--from", "swanlab-mcp", "swanlab_mcp", ...]`
- **JSON config**: Fixed the `mcpServers` JSON structure (removed stray `...`)
- **Claude Code CLI**: Updated the `claude mcp add` example to use `uvx --from swanlab-mcp swanlab_mcp` instead of `uv run swanlab_mcp`

## Verification

Tested locally:
```bash
$ uvx swanlab-mcp --version
# ERROR: executable `swanlab-mcp` not found

$ uvx --from swanlab-mcp swanlab_mcp --version
# Works correctly
```